### PR TITLE
Remove UseHttpsRedirection

### DIFF
--- a/Api/Program.cs
+++ b/Api/Program.cs
@@ -34,8 +34,6 @@ public class Program
             app.UseSwaggerUI();
         }
 
-        app.UseHttpsRedirection();
-
         app.UseAuthorization();
 
 


### PR DESCRIPTION
Should allow for running the app if the dotnet dev cert can't be installed.